### PR TITLE
Update Header.vue with new doc link

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -39,7 +39,7 @@
 							</RouterLink>
 						</MenuItem>
 						<MenuItem as="li">
-							<a href="https://pieroit.github.io/cheshire-cat" target="_blank">📖 Docs</a>
+							<a href="https://cheshire-cat-ai.github.io/core/" target="_blank">📖 Docs</a>
 						</MenuItem>
 					</MenuItems>
 				</Transition>
@@ -70,7 +70,7 @@
 						⚙️ Settings
 					</RouterLink>
 				</li>
-				<li><a href="https://pieroit.github.io/cheshire-cat" target="_blank">📖 Docs</a></li>
+				<li><a href="https://cheshire-cat-ai.github.io/core/" target="_blank">📖 Docs</a></li>
 			</ul>
 		</div>
 		<div class="navbar-end">


### PR DESCRIPTION
L'indirizzo alla documentazione nella barra in alto era rimasto quello vecchio.