### PR TITLE
FIX: wipe memory modal reopen bug

### DIFF
--- a/src/views/MemoryView.vue
+++ b/src/views/MemoryView.vue
@@ -41,7 +41,7 @@ const wipeMemory = async () => {
 		if (!selected) return
 		if (selected === 'all') await wipeAllCollections()
 		else await wipeCollection(selected)
-		boxWipe.value?.toggleModal()
+		if (boxWipe.value?.isOpen) boxWipe.value?.toggleModal()
 	}
 }
 


### PR DESCRIPTION
## Problem

1. go to Memory tab
2.  click wipe memory
3. modal "Wipe Collection" will appear, click "Yes"
4. click outside the modal while operation is still ongoing

issue: modal will close, once the operation is completed, modal will pop up again
proposed solution: do not reopen the modal if closed
[wipe_memory_modal_bug.webm](https://github.com/cheshire-cat-ai/admin-vue/assets/9247877/36a81d4f-c911-4c30-b64c-057c084c7b2c)


## Fix

Fixed by applying toggleModal only if isOpen is true.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
