### PR TITLE
fix: admin page scroll

### DIFF
--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -6,6 +6,7 @@ import ModalBox from '@components/ModalBox.vue'
 import { capitalize } from 'lodash'
 
 const messagesStore = useMessages()
+const route = useRoute()
 const { dispatchMessage, selectRandomDefaultMessages } = messagesStore
 const { currentState: messagesState } = storeToRefs(messagesStore)
 
@@ -163,7 +164,10 @@ const wipeHistory = async () => {
 	if (res) messagesState.value.messages = []
 }
 
-const scrollToBottom = () => window.scrollTo({ behavior: 'smooth', left: 0, top: document.body.scrollHeight })
+const scrollToBottom = () => {
+	const routePath = route.path?.toString()
+	if (routePath === '/') window.scrollTo({ behavior: 'smooth', left: 0, top: document.body.scrollHeight })
+}
 </script>
 
 <template>


### PR DESCRIPTION
# Description

Fixed scrolling to bottom on `plugins` route
if waiting for cat's answer in `home` route

Fixes issue #67

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
