### PR TITLE
fix chat textarea to vertically align center for single line

### DIFF
--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -304,7 +304,7 @@ const scrollToBottom = () => {
 						v-model.trim="userMessage"
 						:disabled="inputDisabled"
 						autofocus
-						:class="'textarea block max-h-20 w-full resize-none overflow-auto bg-base-200 pr-10 !outline-2 shadow-lg !outline-offset-0'"
+						:class="'textarea block max-h-20 w-full resize-none overflow-auto bg-base-200 pr-10 !outline-2 shadow-lg !outline-offset-0 pt-[10px]'"
 						:placeholder="generatePlaceholder(messagesState.loading, isListening, messagesState.error)"
 						@keydown="preventSend" />
 					<div class="absolute right-2 top-1/2 -translate-y-1/2">


### PR DESCRIPTION
# Description

Before:
![Screenshot 2024-08-24 at 16 22 29](https://github.com/user-attachments/assets/3a165e5d-8222-4396-8042-4c9afdda321b)

----

After:
![Screenshot 2024-08-24 at 16 22 40](https://github.com/user-attachments/assets/8b63c676-978d-4ae7-b3a1-639bcb66ae89)

Make sure multiline mode still works correctly

https://github.com/user-attachments/assets/3899d3fb-13e5-4593-bcf3-cbe1c8e9b1d8




## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
