### PR TITLE
add: on/off label on activate/deactivate plugin

### DIFF
--- a/src/views/PluginsView.vue
+++ b/src/views/PluginsView.vue
@@ -228,6 +228,8 @@ watchEffect(() => {
 											item.active = res ? item.active : false
 										}
 									" />
+									<span v-if="item.active">On</span>
+									<span v-else>Off</span>
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
# Description

Added On/Off label near plugin button activation for explicitly telling the plugin status (activated/deactivated).

Follows a preview:

![Screenshot from 2024-10-16 11-01-41](https://github.com/user-attachments/assets/9ddd309b-b3ec-4747-b64e-0c842a0d2dcc)


Related to issue #99 

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
