### PR TITLE
Remove custom CSS style for thead and tfoot

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -101,9 +101,6 @@
 	.chat-bubble table {
 		@apply !table !table-xs;
 	}
-	.chat-bubble table :where(thead, tfoot) {
-		@apply !text-base-100;
-	}
 	.chat-bubble pre {
 		@apply !my-4 !whitespace-pre-wrap;
 	}


### PR DESCRIPTION
# Description

In chat bubbles tables, the thead and the tfoot were hidden, because their color was set using a custom CSS property to the same as the background.
I don't know if it's a bug or a feature, but I removed some CSS lines for now. Let me know if you prefer to update it to use a custom color or style for them.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
